### PR TITLE
Expose user info to extensions

### DIFF
--- a/browser/containers/App.tsx
+++ b/browser/containers/App.tsx
@@ -39,10 +39,10 @@ interface Props {
 
 interface State {
   user: {
-    access: string[];
     name: string;
-    groups: string;
-    ossApproved: boolean;
+    access: string[];
+    groups: string[];
+    roles: string[];
   };
 }
 
@@ -57,24 +57,16 @@ export class App extends React.Component<Props, State> {
     super(props);
     this.state = {
       user: {
-          access: [],
-          name: '',
-          groups: '',
-          ossApproved: false,
-        },
+        name: '',
+        access: [],
+        groups: [],
+        roles: [],
+      },
     };
   };
 
   componentWillMount() {
-    reqJSON('/api/user/access').then(privs => {
-      const access = privs.access;
-      this.setState({
-        user: {
-          ...this.state.user,
-          access,
-        },
-      });
-    });
+    reqJSON('/api/user').then(user => this.setState({ user }));
   };
 
   dismissError = () => {
@@ -114,11 +106,10 @@ export class App extends React.Component<Props, State> {
 
   render() {
     const { generalError } = this.props;
-    let adminLink = null;
-    if (this.state.user.access.includes(AccessTypes.admin)) {
-      adminLink = (<li className="nav-item"><Link to="/admin" className="nav-link">Admin</Link></li>);
-    };
+    const { user } = this.state;
+
     const securedRoutes = this.buildSecureRoutes();
+
     return (
       <div>
         <nav className="navbar navbar-expand-sm navbar-light bg-light">
@@ -127,10 +118,14 @@ export class App extends React.Component<Props, State> {
           </ExtensionPoint>
           <div className="collapse navbar-collapse">
             <ul className="nav navbar-nav ml-auto">
-              {adminLink}
-              <ExtensionPoint ext="navbar-links" />
+              { user.access.includes(AccessTypes.admin) &&
+                (<li className="nav-item">
+                  <Link to="/admin" className="nav-link">Admin</Link>
+                </li>)
+              }
+              <ExtensionPoint ext="navbar-links" user={user} />
               <li className="nav-item">
-                <ExtensionPoint ext="navbar-contribution">
+                <ExtensionPoint ext="navbar-contribution" user={user}>
                   <Link to="/contribute" className="nav-link">New Contribution</Link>
                 </ExtensionPoint>
               </li>
@@ -146,7 +141,7 @@ export class App extends React.Component<Props, State> {
                 </a>
               </li>
             </ul>
-            <ExtensionPoint ext="navbar-end" />
+            <ExtensionPoint ext="navbar-end" user={user} />
           </div>
         </nav>
 

--- a/browser/extensions/README.md
+++ b/browser/extensions/README.md
@@ -49,7 +49,8 @@ Add additional links to the navbar.
 A [React functional component].
 
 * Input:
-    * `props` - React props. Empty.
+    * `props` - React props:
+        * `user` - an object describing the current user. See `App.tsx` for structure.
 * Return: a rendered React component.
 
 ### `navbar-contribution`
@@ -59,8 +60,9 @@ Allows for replacing the contribution system.
 A [React functional component].
 
 * Input:
-    * `props` - React props. Empty.
-     * `children` - The default contribution process.
+    * `props` - React props:
+        * `children` - The default contribution process.
+        * `user` - an object describing the current user. See `App.tsx` for structure.
 * Return: a rendered React component.
 
 ### `navbar-end`
@@ -70,7 +72,8 @@ Add additional items to the end of the navbar.
 A [React functional component].
 
 * Input:
-    * `props` - React props. Empty.
+    * `props` - React props:
+        * `user` - an object describing the current user. See `App.tsx` for structure.
 * Return: a rendered React component.
 
 ### `ldap-info`
@@ -80,8 +83,8 @@ Area for displaying additional ldap information.
 A [React functional component].
 
 * Input:
-    * `props` - React props. Empty.
-    * `alias` - Alias of the user accessing the page. This is used for accessing the users LDAP info.
+    * `props` - React props:
+        * `alias` - Alias of the user accessing the page. This is used for accessing the users LDAP info.
 * Return: a rendered React component.
 
 ### `landing-content`
@@ -91,7 +94,7 @@ Replace the default landing content.
 A [React functional component].
 
 * Input:
-    * `props` - React props. Empty.
+    * `props` - React props:
         * `children` - Default landing metrics.
 * Return: a rendered React component.
 

--- a/config/default.js
+++ b/config/default.js
@@ -47,6 +47,10 @@ config.approver = {
   posixGroup: '', // approver posix group
 };
 
+config.roles = {
+  // 'role-name': ['group-1', 'group-2'],
+}
+
 // Users defined for dropdowns
 config.display = {
   signatory: [

--- a/server/auth/ldap.ts
+++ b/server/auth/ldap.ts
@@ -18,7 +18,7 @@ import config from '../config';
 
 export class LDAPAuth {
 
-  getActiveUser(request) {
+  getActiveUser(request): string {
     let remoteUser = request.get('X-FORWARDED-USER') || `${config.fallbackUser}@`;
     return remoteUser.substring(0, remoteUser.indexOf('@'));
   }


### PR DESCRIPTION
This change also consolidates the /user/access route back into
/user. Future work needed on roles vs access vs groups present
in this structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
