### PR TITLE
Fix bad Promise comparison in contribution submission

### DIFF
--- a/browser/components/GithubLink.tsx
+++ b/browser/components/GithubLink.tsx
@@ -78,7 +78,7 @@ class GithubLink extends React.Component<Partial<Props>, State> {
     } else {
       const getAlert = () => (
         <SweetAlert title="Failure to update link" onConfirm={this.hideAlertRedirect}>
-          Unable to save contribution link. If this problem persists, contact osa-pm@amazon.com.
+          Unable to save your contribution link. Please contact your site administrator.
         </SweetAlert>
       );
       this.setState({

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -233,7 +233,7 @@ router.post('/contributions/update', async (req, res, next) => {
 });
 
 router.post('/contributions/update/link', async (req, res, next) => {
-  const user = getUser(req);
+  const user = await getUser(req);
   if (user === req.body.user) {
     const confirm = await contributionsAPI.updateContributionLink(req, req.body);
     if (!confirm) { // success returns null
@@ -248,10 +248,10 @@ router.post('/contributions/update/link', async (req, res, next) => {
       });
     };
   } else {
-    winston.warn('$1 not allowed to update contributions github link', [user]);
+    winston.warn(`${user} not allowed to update contribution link`);
     res.status(401);
     res.send({
-      error: 'Not allowed to update contributions github link',
+      error: 'Not allowed to update contribution link',
     });
   };
 });


### PR DESCRIPTION
I'm going to see if we can get additional lints / type checking to prevent this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
