### PR TITLE
Clean up error handling and requests

### DIFF
--- a/browser/actions/employeeAction.ts
+++ b/browser/actions/employeeAction.ts
@@ -53,9 +53,9 @@ export function receiveAliasNames(alias) {
 // Action creators
 export function fetchDataListAlias() {
   return (dispatch) => {
-    return  reqJSON(RECEIVE_ALIAS_NAMES).then((alias) => {
+    return reqJSON(RECEIVE_ALIAS_NAMES).then((alias) => {
       dispatch(receiveAliasNames(alias));
-    }) ;
+    });
   };
 }
 

--- a/browser/components/ContributionsForm.tsx
+++ b/browser/components/ContributionsForm.tsx
@@ -145,7 +145,7 @@ class ContributionsForm extends React.Component<Partial<Props>, State> {
                         onChange={this.toggleProjectSelect} />
                       <label htmlFor="newProject" className="form-check-label">
                         New Project
-                </label>
+                      </label>
                     </span>
                   </div>
                   <input id="new-project-text" type="text" className="form-control"

--- a/browser/components/ContributionsTable.tsx
+++ b/browser/components/ContributionsTable.tsx
@@ -57,13 +57,9 @@ class ContributionsTable extends React.Component<Props, State> {
   createTables = (contributionList) => {
     const type = this.props.type;
     let tableProps = {};
-    /*
-      These are the items that will be stored in state and the same name
-      which is why I have used the abbreviations here to reduce confusion.
-    */
-    const t = new Map();
-    const pN = new Array();
-    let sP = null;
+    const newTables = new Map();
+    const newProjectNames = new Array();
+
     switch (type) {
       case 'all':
         tableProps = {
@@ -79,15 +75,15 @@ class ContributionsTable extends React.Component<Props, State> {
         break;
     }
     for (const [key, value] of Object.entries(contributionList)) {
-      t.set(key, ContributionsTable.renderTables(key, value, tableProps));
-      pN.push(key.toLowerCase());
+      newTables.set(key, ContributionsTable.renderTables(key, value, tableProps));
+      newProjectNames.push(key.toLowerCase());
     }
-    pN.sort();
-    sP = null;
+    newProjectNames.sort();
+
     this.setState({
-      tables: t,
-      projectNames: pN,
-      selectedProject: sP,
+      tables: newTables,
+      projectNames: newProjectNames,
+      selectedProject: null,
     });
   }
 

--- a/browser/containers/Contributions.tsx
+++ b/browser/containers/Contributions.tsx
@@ -22,43 +22,34 @@ interface Props {
 }
 
 interface State {
-  user: {
-    name: string;
-  };
-  projects: any;
-  approvers: any;
+  projects: any[];
+  approvers: any[];
 }
 
 export default class Contributions extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      user: {
-        name: '',
-      },
-      projects: {},
-      approvers: {},
+      projects: [],
+      approvers: [],
     };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     // Maybe store user info in redux once I have session stuff
     const projects = await reqJSON('/api/projects');
-    this.setState({
-      projects: projects.projectList,
-    });
-
     const approvers = await reqJSON('/api/approvers');
     this.setState({
-      approvers: {
-        name: approvers.approverList,
-      },
+      projects: projects.projectList,
+      approvers: approvers.approverList,
     });
   }
 
   render() {
+    const { approvers, projects } = this.state;
+
     return (
-      <ContributionsForm approvers={this.state.approvers.name} projects={this.state.projects} />
+      <ContributionsForm approvers={approvers} projects={projects} />
     );
   }
 }

--- a/browser/containers/List.tsx
+++ b/browser/containers/List.tsx
@@ -29,15 +29,17 @@ class List extends React.Component<{}, State> {
     };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     const contributions = await reqJSON('/api/contributions');
     this.setState({contributionList: contributions.contributionList});
   }
 
   render() {
+    const { contributionList } = this.state;
+
     return (
       <div id="contributionsListAll">
-        <ContributionsTable contributionList={ this.state.contributionList } type="all" />
+        <ContributionsTable contributionList={contributionList} type="all" />
       </div>
     );
   }

--- a/browser/modules/claLogger.ts
+++ b/browser/modules/claLogger.ts
@@ -20,20 +20,20 @@ import { postJSON } from '../util/index';
 // New Cla
 export function postNewCla(cla) {
   return (dispatch) => {
-    return postJSON('/api/cla/submit', JSON.stringify(cla)).catch((error) => console.error(error));
+    return postJSON('/api/cla/submit', cla).catch((error) => console.error(error));
   };
 }
 
 // update function for edit cla
 export function updateCla(claUpdated) {
   return (dispatch) => {
-    return postJSON('/api/cla/update', JSON.stringify(claUpdated)).catch((error) => console.error(error));
+    return postJSON('/api/cla/update', claUpdated).catch((error) => console.error(error));
   };
 }
 
 // delete entries from cla
 export function deleteClaEntry(id) {
   return (dispatch) => {
-    return postJSON('/api/cla/delete', JSON.stringify(id)).catch((error) => console.error(error));
+    return postJSON('/api/cla/delete', id).catch((error) => console.error(error));
   };
 }

--- a/browser/modules/contributions.ts
+++ b/browser/modules/contributions.ts
@@ -34,7 +34,7 @@ export default function reducer(state = initial, action: any = {}) {
 /*** Action creators ***/
 export function addContribution(contrib) {
   return (dispatch) => {
-    return postJSON('/api/contributions/new', JSON.stringify(contrib))
+    return postJSON('/api/contributions/new', contrib)
       .then(() => {
         history.push('/contribute');
         window.location.reload();
@@ -45,7 +45,7 @@ export function addContribution(contrib) {
 
 export function approveContribution(contrib) {
   return (dispatch) => {
-    return postJSON('/api/contributions/approve', JSON.stringify(contrib))
+    return postJSON('/api/contributions/approve', contrib)
       .then(() => {
         history.push('/admin');
       })
@@ -55,21 +55,21 @@ export function approveContribution(contrib) {
 
 export function updateContribution(contrib) {
   return (dispatch) => {
-    return postJSON('/api/contributions/update', JSON.stringify(contrib))
+    return postJSON('/api/contributions/update', contrib)
       .catch((error) => console.error(error));
   };
 }
 
 export function addContributionAutoApproval(contrib) {
   return (dispatch) => {
-    return postJSON('/api/contributions/newautoapproval', JSON.stringify(contrib))
-    .catch((error) => console.error(error));
+    return postJSON('/api/contributions/newautoapproval', contrib)
+      .catch((error) => console.error(error));
   };
 }
 
 export function updateGithubLink(contrib) {
   return (dispatch) => {
-    return postJSON('/api/contributions/update/link', JSON.stringify(contrib))
-    .catch((error) => console.info(error));
+    return postJSON('/api/contributions/update/link', contrib)
+      .catch((error) => console.info(error));
   };
 }

--- a/browser/util/index.ts
+++ b/browser/util/index.ts
@@ -18,25 +18,40 @@ import 'whatwg-fetch';
  *
  * Write more that will cover use cases
  */
-export async function reqJSON(url, method = 'GET') {
-  const f = await fetch(url, {
-    credentials: 'same-origin',
+export async function reqJSON(url: string, obj?: any, method = 'GET'): Promise<any> {
+  const body = obj !== undefined ? JSON.stringify(obj) : undefined;
+  const res = await fetch(url, {
     method,
-  });
-  // Unpack promises
-  const hold = await f.json();
-  return hold;
-}
-
-export async function postJSON(url, obj, method = 'POST') {
-  const f = await fetch(url, {
     credentials: 'same-origin',
-    method,
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
     },
-    body: obj,
+    body,
   });
-  return await f;
+
+  // happy? return
+  if (res.ok) {
+    return res.json();
+  }
+
+  // error handling
+  let error: Error & {code?: number; response?: any};
+  try {
+    // assume it's json first; try to get the message out of it
+    const json = await res.json();
+    error = new Error(json.error);
+  } catch (ex) {
+    // otherwise just use the HTTP status code
+    error = new Error(res.statusText);
+  }
+
+  // package it up nicely and throw
+  error.code = res.status;
+  error.response = res;
+  throw error;
+}
+
+export async function postJSON(url: string, obj?: any): Promise<any> {
+  return reqJSON(url, obj, 'POST');
 }

--- a/server/db/contributions.ts
+++ b/server/db/contributions.ts
@@ -83,21 +83,6 @@ export async function addNewContribution(project_id, description, contribution_d
   );
 }
 
-// Auto approval for simple contributions
-export async function addNewContributionApproved(project_id, description, contribution_date,
-                                                 approver, contributor_alias, contribution_project_review,
-                                                 githublink, approvalNotes) {
-  return await pg().none( // fill out all fields as it was easier
-    'insert into contributions (project_id, contribution_description, contribution_date, ' +
-    'contributor_alias, contribution_github_status, contribution_commit_url, approver_id, ' +
-    'approval_status, approval_notes, approval_date, contribution_submission_date, ' +
-    'contribution_closed_date, contribution_project_review) ' +
-    'values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)',
-    [project_id, description, contribution_date, contributor_alias, 'pending', githublink, 4,
-    'approved', approvalNotes, null, contribution_date, null, contribution_project_review],
-  );
-}
-
 // Update approval column of a specific contribution
 export async function approveContribution(id, notes, status) {
   return await pg().none(


### PR DESCRIPTION
* reqJSON used everywhere
* postJSON is a convenience (reqJSON w/ POST)
* server errors throw; there's still a lot of missing error handling
  but it's a start
* server errors by exception instead of manually sending errors
* 500s now send json errors (no more parse errors on client)
* dropped unused "newautoapproval" route

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
