### PR TITLE
404 + logic fix

### DIFF
--- a/browser/components/GithubLink.tsx
+++ b/browser/components/GithubLink.tsx
@@ -94,8 +94,7 @@ class GithubLink extends React.Component<Partial<Props>, State> {
     const display = [];
     for (const key of Object.keys(this.state.contributionList)) {
       const value = this.state.contributionList[key];
-      const status = value.approval_status;
-      if (status === 'approved-pending-link') {
+      if (!value.contribution_commit_url) {
         display.push(
           <tr key={value.contribution_id}>
             <td>{value.project_name}</td>
@@ -120,10 +119,10 @@ class GithubLink extends React.Component<Partial<Props>, State> {
     return (
       <div className="container">
         <div className="row">
-          <div id="github-link-container" className="col-lg-9"><br/><br/>
+          <div id="github-link-container" className="col-lg-12"><br/><br/>
             <h3>Your contributions awaiting links</h3>
             { this.state.alert }
-            <table className="table table-striped table-bordered">
+            <table className="table table-striped table-bordered mt-3">
               <thead>
                 <tr key="github-link-table-head">
                   <th>Project</th>

--- a/server/api/contributions/index.ts
+++ b/server/api/contributions/index.ts
@@ -64,11 +64,12 @@ export async function getSingleContribution(req, id) {
 
 export async function approveContribution(req, body) {
   // Add check to ensure approving user has correct rights
-  return await dbContribution.approveContribution(
+  await dbContribution.approveContribution(
     body.contributionId,
     body.approvalNotes,
     body.approvalStatus,
   );
+  return { contributionId: body.contributionId };
 }
 
 export async function addNewContribution(req, body) {


### PR DESCRIPTION
On submitting links: show anything with a missing link, regardless of status. This will set its state to approved-pending-upstream, but that should be fine (we'd have to fetch the actual state in the future, anyway).

On the 404: dbContribution.approveContribution returns nothing -> pack is a 404. I'm... actually not sure how that worked before.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
