### PR TITLE
Diff check: report chunk sizes to support empty but valid diffs

### DIFF
--- a/server/api/contributions/index.ts
+++ b/server/api/contributions/index.ts
@@ -117,15 +117,15 @@ export async function addNewAutoApprovedContribution(req, body, user) {
 }
 
 export async function diffCheck(req, body) {
-  const size = getDiffSize(body.diff);
-  if (size === 0) {
+  const { lines, chunks } = getDiffSize(body.diff);
+  if (chunks === 0) {
     throw new RequestError(
       'Submitted text is not a unified diff, or it had no changes'
     );
   }
   return {
-    ok: size < config.contributions.autoApprove.diffLimit,
-    size,
+    ok: lines < config.contributions.autoApprove.diffLimit,
+    lines,
   };
 }
 

--- a/server/util/diffcheck.spec.ts
+++ b/server/util/diffcheck.spec.ts
@@ -1,0 +1,80 @@
+/* Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { getDiffSize } from './diffcheck';
+
+describe('diff checker', () => {
+  it('counts lines', () => {
+    expect(getDiffSize(diff1)).toEqual({
+      lines: 2,
+      chunks: 2,
+    });
+  });
+
+  it('doesnt fail on invalid diff', () => {
+    expect(getDiffSize(diff2)).toEqual({
+      lines: 0,
+      chunks: 0,
+    });
+  });
+
+  it('ignores space changes', () => {
+    expect(getDiffSize(diff3)).toEqual({
+      lines: 1,
+      chunks: 3,
+    });
+  });
+
+  it('reports chunk sizes even with no line changes', () => {
+    expect(getDiffSize(diff4)).toEqual({
+      lines: 0,
+      chunks: 2,
+    });
+  });
+});
+
+// two line count, two chunks
+const diff1 = `
+blah blah
+@@ hello
+ oariestn arsetiars
+ aioretn;awyuft
++ awfoitenarsitears
++//yarsiteonarsot
+-oufarst
+`;
+
+// 0 lines, 0 chunks
+const diff2 = `
+not a real diff
+`;
+
+// 1 line count (spacing change), 3 chunks
+const diff3 = `
+@@
+-hello
++   hello
+ oaresntoaeirs t
+ arstarst
++  arsotnyufpt
+`;
+
+const diff4 = `
+@@
+ oarpiutnasotars
+ airsthairsetn
+-hello
++hello
+ ioaorste
+`;

--- a/server/util/diffcheck.ts
+++ b/server/util/diffcheck.ts
@@ -110,8 +110,13 @@ function getDiffChunks(diff: string): Array<[Chunk, string[]]> {
   return chunks;
 }
 
-export function getDiffSize(diff: string): number {
+export function getDiffSize(diff: string): { chunks: number; lines: number } {
   const chunks = getDiffChunks(diff);
+
+  // get the total number of chunks for basic validation
+  const numChunks = chunks.filter(
+    chunk => chunk[0] === Chunk.Add || chunk[0] === Chunk.Del
+  ).length;
 
   chunks.forEach((chunk, i) => {
     if (i === 0) {
@@ -138,7 +143,12 @@ export function getDiffSize(diff: string): number {
   });
 
   // get the number of lines in add chunks
-  return chunks
+  const numLines = chunks
     .filter(chunk => chunk[0] === Chunk.Add)
     .reduce((acc, curr) => acc + curr[1].length, 0);
+
+  return {
+    chunks: numChunks,
+    lines: numLines,
+  };
 }


### PR DESCRIPTION
This fixes the issue of the diff check route claiming a diff wasn't valid, when it simply had 0 lines to report (but a non-zero count of add/delete chunks).

Tests included.