### PR TITLE
fixed report calendar browser compatibility

### DIFF
--- a/browser/components/GroupsTable.tsx
+++ b/browser/components/GroupsTable.tsx
@@ -16,11 +16,10 @@ import SweetAlert from 'react-bootstrap-sweetalert';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import ReactTable from 'react-table';
+import ReportForm from './ReportForm.tsx';
 import StrategicTableLinkCell from './StrategicTableLinkCell';
 
 import * as actions from '../actions/strategicActions';
-import * as utils from '../util/generateReport';
-import { reqJSON } from '../util/index';
 
 interface Props {
   updateAdminNav: (navpage) => void;
@@ -60,9 +59,9 @@ class GroupsTable extends React.Component<Props, State> {
     this.props.updateAdminNav('editGroup');
   };
 
-  handleDownload = e => {
+  handleDownload = async e => {
     const groupId = e.target.id;
-    this.setState({ groupId });
+    await this.setState({ groupId });
     this.alert();
   };
 
@@ -71,71 +70,17 @@ class GroupsTable extends React.Component<Props, State> {
       alert: (
         <SweetAlert
           title="Report Date"
-          onConfirm={this.downloadReport}
+          onConfirm={this.hideAlert}
           showConfirm={false}
         >
           Please select the specific month and year for the report.
-          <form onSubmit={this.downloadReport}>
-            <div className="form-row">
-              <div className="form-group col">
-                <label htmlFor="month">Select month</label>
-                <select className="form-control" id="month">
-                  <option value="01">January</option>
-                  <option value="02">February</option>
-                  <option value="03">March</option>
-                  <option value="04">April</option>
-                  <option value="05">May</option>
-                  <option value="06">June</option>
-                  <option value="07">July</option>
-                  <option value="08">August</option>
-                  <option value="09">September</option>
-                  <option value="10">October</option>
-                  <option value="11">November</option>
-                  <option value="12">December</option>
-                </select>
-              </div>
-              <div className="form-group col">
-                <label htmlFor="year">Select year</label>
-                <select className="form-control" id="year">
-                  <option>2018</option>
-                  <option>2017</option>
-                  <option>2016</option>
-                  <option>2015</option>
-                  <option>2014</option>
-                </select>
-              </div>
-            </div>
-            <div className="row justify-content-around">
-              <button
-                className="btn btn-warning btn-lg col-4"
-                onClick={this.hideAlert}
-              >
-                {' '}
-                Cancel{' '}
-              </button>
-              <button type="submit" className="btn btn-primary btn-lg col-4">
-                {' '}
-                Download{' '}
-              </button>
-            </div>
-          </form>
+          <ReportForm
+            groupId={this.props.groups[this.state.groupId].group_id}
+            hideAlert={this.hideAlert}
+          />
         </SweetAlert>
       ),
     });
-  };
-
-  downloadReport = async e => {
-    e.preventDefault();
-    const fields = e.target.elements;
-    const group = this.props.groups[this.state.groupId];
-    const report = await reqJSON(
-      `/api/strategic/report/${group.group_id}/${fields.year.value}-${
-        fields.month.value
-      }`
-    );
-    report.date = `${fields.year.value}-${fields.month.value}`;
-    utils.onClickDownload(report);
-    this.hideAlert();
   };
 
   hideAlert = () => {

--- a/browser/components/GroupsTable.tsx
+++ b/browser/components/GroupsTable.tsx
@@ -70,26 +70,70 @@ class GroupsTable extends React.Component<Props, State> {
     this.setState({
       alert: (
         <SweetAlert
-          type="input"
-          showCancel={true}
-          inputType="month"
-          title="Report Month"
+          title="Report Date"
           onConfirm={this.downloadReport}
-          onCancel={this.hideAlert}
-          cancelBtnBsStyle="warning"
+          showConfirm={false}
         >
           Please select the specific month and year for the report.
+          <form onSubmit={this.downloadReport}>
+            <div className="form-row">
+              <div className="form-group col">
+                <label htmlFor="month">Select month</label>
+                <select className="form-control" id="month">
+                  <option value="01">January</option>
+                  <option value="02">February</option>
+                  <option value="03">March</option>
+                  <option value="04">April</option>
+                  <option value="05">May</option>
+                  <option value="06">June</option>
+                  <option value="07">July</option>
+                  <option value="08">August</option>
+                  <option value="09">September</option>
+                  <option value="10">October</option>
+                  <option value="11">November</option>
+                  <option value="12">December</option>
+                </select>
+              </div>
+              <div className="form-group col">
+                <label htmlFor="year">Select year</label>
+                <select className="form-control" id="year">
+                  <option>2018</option>
+                  <option>2017</option>
+                  <option>2016</option>
+                  <option>2015</option>
+                  <option>2014</option>
+                </select>
+              </div>
+            </div>
+            <div className="row justify-content-around">
+              <button
+                className="btn btn-warning btn-lg col-4"
+                onClick={this.hideAlert}
+              >
+                {' '}
+                Cancel{' '}
+              </button>
+              <button type="submit" className="btn btn-primary btn-lg col-4">
+                {' '}
+                Download{' '}
+              </button>
+            </div>
+          </form>
         </SweetAlert>
       ),
     });
   };
 
-  downloadReport = async date => {
+  downloadReport = async e => {
+    e.preventDefault();
+    const fields = e.target.elements;
     const group = this.props.groups[this.state.groupId];
     const report = await reqJSON(
-      `/api/strategic/report/${group.group_id}/${date}`
+      `/api/strategic/report/${group.group_id}/${fields.year.value}-${
+        fields.month.value
+      }`
     );
-    report.date = date;
+    report.date = `${fields.year.value}-${fields.month.value}`;
     utils.onClickDownload(report);
     this.hideAlert();
   };

--- a/browser/components/ReportForm.tsx
+++ b/browser/components/ReportForm.tsx
@@ -1,0 +1,106 @@
+/* Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+import * as React from 'react';
+import * as utils from '../util/generateReport';
+import { reqJSON } from '../util/index';
+
+interface Props {
+  groupId: number;
+  hideAlert: () => void;
+}
+
+interface State {
+  years: any[];
+}
+
+export default class ReportForm extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      years: [],
+    };
+  }
+
+  async componentDidMount() {
+    await this.getYears();
+  }
+
+  downloadReport = async e => {
+    e.preventDefault();
+    const fields = e.target.elements;
+    const report = await reqJSON(
+      `/api/strategic/report/${this.props.groupId}/${fields.year.value}-${
+        fields.month.value
+      }`
+    );
+    report.date = `${fields.year.value}-${fields.month.value}`;
+    utils.onClickDownload(report);
+    this.props.hideAlert();
+  };
+
+  getYears = async () => {
+    const oldest = await reqJSON('/api/contributions/oldest');
+    const current = new Date().getFullYear();
+    const years = [];
+    for (let i = current; i >= oldest.year; i--) {
+      years.push(<option key={i}>{i}</option>);
+    }
+    this.setState({ years });
+  };
+
+  render() {
+    return (
+      <form onSubmit={this.downloadReport}>
+        <div className="form-row">
+          <div className="form-group col">
+            <label htmlFor="month">Select month</label>
+            <select className="form-control" id="month">
+              <option value="01">January</option>
+              <option value="02">February</option>
+              <option value="03">March</option>
+              <option value="04">April</option>
+              <option value="05">May</option>
+              <option value="06">June</option>
+              <option value="07">July</option>
+              <option value="08">August</option>
+              <option value="09">September</option>
+              <option value="10">October</option>
+              <option value="11">November</option>
+              <option value="12">December</option>
+            </select>
+          </div>
+          <div className="form-group col">
+            <label htmlFor="year">Select year</label>
+            <select className="form-control" id="year">
+              {this.state.years}
+            </select>
+          </div>
+        </div>
+        <div className="row justify-content-around">
+          <button
+            className="btn btn-warning btn-lg col-4"
+            onClick={this.props.hideAlert}
+          >
+            {' '}
+            Cancel{' '}
+          </button>
+          <button type="submit" className="btn btn-primary btn-lg col-4">
+            {' '}
+            Download{' '}
+          </button>
+        </div>
+      </form>
+    );
+  }
+}

--- a/browser/containers/Admin.tsx
+++ b/browser/containers/Admin.tsx
@@ -64,6 +64,7 @@ class Admin extends Component<Props, State> {
   async componentDidMount() {
     await this.getApprovals();
     await this.getCLAs();
+    await this.getContributions();
     await this.props.fetchGroups();
   }
 
@@ -78,6 +79,13 @@ class Admin extends Component<Props, State> {
     const claList = await reqJSON('/api/cla');
     this.setState({
       claTable: claList.claTable,
+    });
+  };
+
+  getContributions = async () => {
+    const contributionList = await reqJSON('/api/contributions/bulk');
+    this.setState({
+      contributionList,
     });
   };
 

--- a/browser/containers/Group.tsx
+++ b/browser/containers/Group.tsx
@@ -13,10 +13,10 @@
  */
 import * as React from 'react';
 import SweetAlert from 'react-bootstrap-sweetalert';
-import * as utils from '../util/generateReport';
 import { reqJSON } from '../util/index';
 
 import ProjectTable from '../components/ProjectTable';
+import ReportForm from '../components/ReportForm.tsx';
 import StrategicTable from '../components/StrategicTable';
 import UserTable from '../components/UserTable';
 
@@ -112,70 +112,17 @@ export default class Group extends React.Component<Props, State> {
       alert: (
         <SweetAlert
           title="Report Date"
-          onConfirm={this.downloadReport}
+          onConfirm={this.hideAlert}
           showConfirm={false}
         >
           Please select the specific month and year for the report.
-          <form onSubmit={this.downloadReport}>
-            <div className="form-row">
-              <div className="form-group col">
-                <label htmlFor="month">Select month</label>
-                <select className="form-control" id="month">
-                  <option value="01">January</option>
-                  <option value="02">February</option>
-                  <option value="03">March</option>
-                  <option value="04">April</option>
-                  <option value="05">May</option>
-                  <option value="06">June</option>
-                  <option value="07">July</option>
-                  <option value="08">August</option>
-                  <option value="09">September</option>
-                  <option value="10">October</option>
-                  <option value="11">November</option>
-                  <option value="12">December</option>
-                </select>
-              </div>
-              <div className="form-group col">
-                <label htmlFor="year">Select year</label>
-                <select className="form-control" id="year">
-                  <option>2018</option>
-                  <option>2017</option>
-                  <option>2016</option>
-                  <option>2015</option>
-                  <option>2014</option>
-                </select>
-              </div>
-            </div>
-            <div className="row justify-content-around">
-              <button
-                className="btn btn-warning btn-lg col-4"
-                onClick={this.hideAlert}
-              >
-                {' '}
-                Cancel{' '}
-              </button>
-              <button type="submit" className="btn btn-primary btn-lg col-4">
-                {' '}
-                Download{' '}
-              </button>
-            </div>
-          </form>
+          <ReportForm
+            groupId={this.state.group.group_id}
+            hideAlert={this.hideAlert}
+          />
         </SweetAlert>
       ),
     });
-  };
-
-  downloadReport = async e => {
-    e.preventDefault();
-    const fields = e.target.elements;
-    const report = await reqJSON(
-      `/api/strategic/report/${this.state.group.group_id}/${
-        fields.year.value
-      }-${fields.month.value}`
-    );
-    report.date = `${fields.year.value}-${fields.month.value}`;
-    utils.onClickDownload(report);
-    this.hideAlert();
   };
 
   hideAlert = () => {

--- a/browser/containers/Group.tsx
+++ b/browser/containers/Group.tsx
@@ -111,25 +111,69 @@ export default class Group extends React.Component<Props, State> {
     this.setState({
       alert: (
         <SweetAlert
-          type="input"
-          showCancel={true}
-          inputType="month"
-          title="Report Month"
+          title="Report Date"
           onConfirm={this.downloadReport}
-          onCancel={this.hideAlert}
-          cancelBtnBsStyle="warning"
+          showConfirm={false}
         >
           Please select the specific month and year for the report.
+          <form onSubmit={this.downloadReport}>
+            <div className="form-row">
+              <div className="form-group col">
+                <label htmlFor="month">Select month</label>
+                <select className="form-control" id="month">
+                  <option value="01">January</option>
+                  <option value="02">February</option>
+                  <option value="03">March</option>
+                  <option value="04">April</option>
+                  <option value="05">May</option>
+                  <option value="06">June</option>
+                  <option value="07">July</option>
+                  <option value="08">August</option>
+                  <option value="09">September</option>
+                  <option value="10">October</option>
+                  <option value="11">November</option>
+                  <option value="12">December</option>
+                </select>
+              </div>
+              <div className="form-group col">
+                <label htmlFor="year">Select year</label>
+                <select className="form-control" id="year">
+                  <option>2018</option>
+                  <option>2017</option>
+                  <option>2016</option>
+                  <option>2015</option>
+                  <option>2014</option>
+                </select>
+              </div>
+            </div>
+            <div className="row justify-content-around">
+              <button
+                className="btn btn-warning btn-lg col-4"
+                onClick={this.hideAlert}
+              >
+                {' '}
+                Cancel{' '}
+              </button>
+              <button type="submit" className="btn btn-primary btn-lg col-4">
+                {' '}
+                Download{' '}
+              </button>
+            </div>
+          </form>
         </SweetAlert>
       ),
     });
   };
 
-  downloadReport = async date => {
+  downloadReport = async e => {
+    e.preventDefault();
+    const fields = e.target.elements;
     const report = await reqJSON(
-      `/api/strategic/report/${this.state.group.group_id}/${date}`
+      `/api/strategic/report/${this.state.group.group_id}/${
+        fields.year.value
+      }-${fields.month.value}`
     );
-    report.date = date;
+    report.date = `${fields.year.value}-${fields.month.value}`;
     utils.onClickDownload(report);
     this.hideAlert();
   };

--- a/server/api/contributions/index.ts
+++ b/server/api/contributions/index.ts
@@ -188,3 +188,7 @@ export async function updateContributionLink(req, body) {
     body.link
   );
 }
+
+export async function getOldestContributionYear(req) {
+  return await dbContribution.oldestContributionYear();
+}

--- a/server/api/routes.ts
+++ b/server/api/routes.ts
@@ -180,6 +180,11 @@ router.post('/contributions/approve', async (req, res, next) => {
   }
 });
 
+// get oldest contribution year
+router.get('/contributions/oldest', async (req, res, next) => {
+  pack(contributionsAPI.getOldestContributionYear(req), res, next);
+});
+
 router.get('/contributions/:username', (req, res, next) => {
   pack(
     contributionsAPI.listUserContributions(req, req.params.username),

--- a/server/db/contributions.ts
+++ b/server/db/contributions.ts
@@ -273,3 +273,9 @@ export async function monthlyTotalByUser(projectIds, user, date) {
     [projectIds, month, year, user]
   );
 }
+
+export async function oldestContributionYear() {
+  return await pg().oneOrNone(
+    'select extract(year from min(contribution_date)) as year from contributions'
+  );
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the report calendar from a month input to a dropdown for month and year to be compatible on Safari and Firefox.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
